### PR TITLE
Cache tile mode rects (#443)

### DIFF
--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -6,6 +6,7 @@ var name := "" setget name_changed
 var size : Vector2 setget size_changed
 var undo_redo : UndoRedo
 var tile_mode : int = Global.TileMode.NONE
+var tile_mode_rects := [] # Cached to avoid recalculation
 var undos := 0 # The number of times we added undo properties
 var has_changed := false setget has_changed_changed
 var frames := [] setget frames_changed # Array of Frames (that contain Cels)
@@ -40,6 +41,7 @@ func _init(_frames := [], _name := tr("untitled"), _size := Vector2(64, 64)) -> 
 	frames = _frames
 	name = _name
 	size = _size
+	update_tile_mode_rects()
 	select_all_pixels()
 
 	undo_redo = UndoRedo.new()
@@ -362,6 +364,7 @@ func name_changed(value : String) -> void:
 
 func size_changed(value : Vector2) -> void:
 	size = value
+	update_tile_mode_rects()
 	if Global.selection_rectangle._selected_rect.has_no_area():
 		select_all_pixels()
 
@@ -568,13 +571,12 @@ func has_changed_changed(value : bool) -> void:
 
 
 func get_tile_mode_rect() -> Rect2:
-	match Global.current_project.tile_mode:
-		Global.TileMode.NONE:
-			return Rect2(Vector2.ZERO, size)
-		Global.TileMode.X_AXIS:
-			return Rect2(Vector2(-1, 0) * size, Vector2(3, 1) * size)
-		Global.TileMode.Y_AXIS:
-			return Rect2(Vector2(0, -1) * size, Vector2(1, 3) * size)
-		Global.TileMode.BOTH:
-			return Rect2(Vector2(-1, -1) * size, Vector2(3, 3) * size)
-	return Rect2()
+	return tile_mode_rects[tile_mode]
+
+
+func update_tile_mode_rects() -> void:
+	tile_mode_rects.resize(Global.TileMode.size())
+	tile_mode_rects[Global.TileMode.NONE] = Rect2(Vector2.ZERO, size)
+	tile_mode_rects[Global.TileMode.BOTH] = Rect2(Vector2(-1, -1) * size, Vector2(3, 3) * size)
+	tile_mode_rects[Global.TileMode.X_AXIS] = Rect2(Vector2(-1, 0) * size, Vector2(3, 1) * size)
+	tile_mode_rects[Global.TileMode.Y_AXIS] = Rect2(Vector2(0, -1) * size, Vector2(1, 3) * size)

--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -131,7 +131,7 @@ func update_mirror_brush() -> void:
 
 func update_mask() -> void:
 	var size := _get_draw_image().get_size()
-	# Faster then zeroing PoolByteArray directly. See: https://github.com/Orama-Interactive/Pixelorama/pull/439
+	# Faster than zeroing PoolByteArray directly. See: https://github.com/Orama-Interactive/Pixelorama/pull/439
 	var nulled_array := []
 	nulled_array.resize(size.x * size.y)
 	_mask = PoolByteArray(nulled_array)
@@ -363,7 +363,6 @@ func _create_blended_brush_image(image : Image) -> Image:
 	var brush := Image.new()
 	brush.copy_from(image)
 	brush = _blend_image(brush, tool_slot.color, _brush_interpolate / 100.0)
-	brush.unlock()
 	brush.resize(size.x, size.y, Image.INTERPOLATE_NEAREST)
 	return brush
 
@@ -378,6 +377,7 @@ func _blend_image(image : Image, color : Color, factor : float) -> Image:
 				var color_new := color_old.linear_interpolate(color, factor)
 				color_new.a = color_old.a
 				image.set_pixel(x, y, color_new)
+	image.unlock()
 	return image
 
 
@@ -394,9 +394,9 @@ func _create_brush_indicator() -> BitMap:
 
 
 func _create_image_indicator(image : Image) -> BitMap:
-			var bitmap := BitMap.new()
-			bitmap.create_from_image_alpha(image, 0.0)
-			return bitmap
+	var bitmap := BitMap.new()
+	bitmap.create_from_image_alpha(image, 0.0)
+	return bitmap
 
 
 func _create_pixel_indicator(size : int) -> BitMap:

--- a/src/UI/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer.gd
@@ -284,7 +284,7 @@ func view_menu_id_pressed(id : int) -> void:
 
 func tile_mode_submenu_id_pressed(id : int) -> void:
 	Global.current_project.tile_mode = id
-	Global.transparent_checker._init_position(id)
+	Global.transparent_checker.fit_rect(Global.current_project.get_tile_mode_rect())
 	for i in Global.TileMode.values():
 		Global.tile_mode_submenu.set_item_checked(i, i == id)
 	Global.canvas.tile_mode.update()

--- a/src/UI/TransparentChecker.gd
+++ b/src/UI/TransparentChecker.gd
@@ -3,7 +3,8 @@ extends ColorRect
 
 func _ready() -> void:
 	rect_size = Global.current_project.size
-	if get_parent().get_parent() == Global.main_viewport:
+	if self == Global.transparent_checker:
+		fit_rect(Global.current_project.get_tile_mode_rect())
 		Global.second_viewport.get_node("Viewport/TransparentChecker")._ready()
 		Global.small_preview_viewport.get_node("Viewport/TransparentChecker")._ready()
 	material.set_shader_param("size", Global.checker_size)
@@ -11,7 +12,6 @@ func _ready() -> void:
 	material.set_shader_param("color2", Global.checker_color_2)
 	material.set_shader_param("follow_movement", Global.checker_follow_movement)
 	material.set_shader_param("follow_scale", Global.checker_follow_scale)
-	_init_position(Global.current_project.tile_mode)
 
 
 func update_offset(offset : Vector2, scale : Vector2) -> void:
@@ -23,17 +23,6 @@ func _on_TransparentChecker_resized() -> void:
 	material.set_shader_param("rect_size", rect_size)
 
 
-func _init_position(tile_mode : int) -> void:
-	match tile_mode:
-		Global.TileMode.NONE:
-			Global.transparent_checker.set_size(Global.current_project.size)
-			Global.transparent_checker.set_position(Vector2.ZERO)
-		Global.TileMode.BOTH:
-			Global.transparent_checker.set_size(Global.current_project.size*3)
-			Global.transparent_checker.set_position(-Global.current_project.size)
-		Global.TileMode.X_AXIS:
-			Global.transparent_checker.set_size(Vector2(Global.current_project.size.x*3, Global.current_project.size.y*1))
-			Global.transparent_checker.set_position(Vector2(-Global.current_project.size.x, 0))
-		Global.TileMode.Y_AXIS:
-			Global.transparent_checker.set_size(Vector2(Global.current_project.size.x*1, Global.current_project.size.y*3))
-			Global.transparent_checker.set_position(Vector2(0, -Global.current_project.size.y))
+func fit_rect(rect : Rect2) -> void:
+	rect_position = rect.position
+	rect_size = rect.size


### PR DESCRIPTION
* Cache tile mode rects

* Make TransparentChecker don't calculate tile mode rect on its own

* Minor fixes

- typo
- formatting
- moved unlock() call to the method where matching lock() was called