### PR TITLE
"SpriteSheet as layer" and "Replace Frame"  import options (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 This update has been brought to you by the contributions of:
 
-Laurenz Reinthaler (Schweini07), kleonc, Variable-ind
+Laurenz Reinthaler (Schweini07), kleonc, Fayez Akhtar (Variable)
 
 ### Added
 - A new pan tool, used to move around the canvas. ([#399](https://github.com/Orama-Interactive/Pixelorama/pull/399))

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -358,7 +358,7 @@ func open_image_as_new_tab(path : String, image : Image) -> void:
 	set_new_tab(project, path)
 
 
-func open_image_as_spritesheet(path : String, image : Image, horizontal : int, vertical : int) -> void:
+func open_image_as_spritesheet_tab(path : String, image : Image, horizontal : int, vertical : int) -> void:
 	var project = Project.new([], path.get_file())
 	project.layers.append(Layer.new())
 	Global.projects.append(project)
@@ -386,6 +386,69 @@ func open_image_as_spritesheet(path : String, image : Image, horizontal : int, v
 			project.frames.append(frame)
 
 	set_new_tab(project, path)
+
+
+func open_image_as_spritesheet_layer(path : String, image : Image, file_name : String, horizontal : int, vertical : int, start_frame : int) -> void:
+	# data needed to slice images
+	horizontal = min(horizontal, image.get_size().x)
+	vertical = min(vertical, image.get_size().y)
+	var frame_width := image.get_size().x / horizontal
+	var frame_height := image.get_size().y / vertical
+
+	# resize canvas to if "frame_width" or "frame_height" is too large
+	var project_width :int = max(frame_width, Global.current_project.size.x)
+	var project_height :int = max(frame_height, Global.current_project.size.y)
+	DrawingAlgos.resize_canvas(project_width, project_height,0 ,0) 
+
+	# slice images
+	var image_no :int = 0
+	for yy in range(vertical):
+		for xx in range(horizontal):
+			var cropped_image := Image.new()
+			cropped_image = image.get_rect(Rect2(frame_width * xx, frame_height * yy, frame_width, frame_height))
+			if (start_frame + (image_no)) < Global.current_project.frames.size():
+				# if frames are already present then fill those first
+				if image_no == 0:
+					open_image_as_new_layer(cropped_image, file_name, start_frame + image_no)
+				else:
+					open_image_at_frame(cropped_image, Global.current_project.layers.size() - 1, start_frame + image_no)
+			else:
+				# if no more frames are present then start making new frames
+				open_image_as_new_frame(cropped_image, Global.current_project.layers.size() - 1)
+			image_no += 1
+
+
+func open_image_at_frame(image : Image, layer_index := 0, frame_index := 0) -> void:
+	var project = Global.current_project
+	image.crop(project.size.x, project.size.y)
+
+	project.undos += 1
+	project.undo_redo.create_action("Replaced Frame")
+	
+	var frames :Array = []
+	# create a duplicate of "project.frames"
+	for i in project.frames.size():
+		var frame := Frame.new()
+		frame.cels = project.frames[i].cels.duplicate(true)
+		frames.append(frame)
+	
+	for i in project.frames.size():
+		if i == frame_index:
+			image.convert(Image.FORMAT_RGBA8)
+			image.lock()
+			frames[i].cels[layer_index] = (Cel.new(image, 1))
+			project.undo_redo.add_do_property(project.frames[i], "cels", frames[i].cels)
+			project.undo_redo.add_undo_property(project.frames[i], "cels", project.frames[i].cels)
+
+	project.undo_redo.add_do_property(project, "frames", frames)
+	project.undo_redo.add_do_property(project, "current_frame", frame_index)
+
+	project.undo_redo.add_undo_property(project, "frames", project.frames)
+	project.undo_redo.add_undo_property(project, "current_frame", project.current_frame)
+	
+	project.undo_redo.add_do_method(Global, "redo")
+	project.undo_redo.add_undo_method(Global, "undo")
+	project.undo_redo.commit_action()
 
 
 func open_image_as_new_frame(image : Image, layer_index := 0) -> void:
@@ -444,6 +507,7 @@ func open_image_as_new_layer(image : Image, file_name : String, frame_index := 0
 
 		project.undo_redo.add_do_property(project.frames[i], "cels", new_cels)
 		project.undo_redo.add_undo_property(project.frames[i], "cels", project.frames[i].cels)
+
 
 	new_layers.append(layer)
 

--- a/src/UI/Dialogs/AboutDialog.gd
+++ b/src/UI/Dialogs/AboutDialog.gd
@@ -140,7 +140,7 @@ func create_contributors() -> void:
 	contributors.create_item(contributor_root).set_text(0, "  Vriska Weaver (henlo-birb)")
 	contributors.create_item(contributor_root).set_text(0, "  Rémi Verschelde (akien-mga)")
 	contributors.create_item(contributor_root).set_text(0, "  gschwind")
-	contributors.create_item(contributor_root).set_text(0, "  Variable-ind")
+	contributors.create_item(contributor_root).set_text(0, "  Fayez Akhtar (Variable)")
 
 
 func create_translators() -> void:

--- a/src/UI/Dialogs/PreviewDialog.tscn
+++ b/src/UI/Dialogs/PreviewDialog.tscn
@@ -82,22 +82,20 @@ margin_right = 151.0
 margin_bottom = 20.0
 mouse_default_cursor_shape = 2
 text = "New tab"
-items = [ "New tab", null, false, 0, null, "Spritesheet (new tab)", null, false, 1, null, "New frame", null, false, 2, null, "New layer", null, false, 3, null, "New palette", null, false, 4, null, "New brush", null, false, 5, null, "New pattern", null, false, 6, null ]
-selected = 0
 
-[node name="SpritesheetOptions" type="HBoxContainer" parent="VBoxContainer/HBoxContainer"]
+[node name="SpritesheetTabOptions" type="HBoxContainer" parent="VBoxContainer/HBoxContainer"]
 visible = false
 margin_left = 155.0
 margin_right = 533.0
 margin_bottom = 24.0
 
-[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/SpritesheetOptions"]
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/SpritesheetTabOptions"]
 margin_top = 5.0
 margin_right = 118.0
 margin_bottom = 19.0
 text = "Horizontal frames:"
 
-[node name="HorizontalFrames" type="SpinBox" parent="VBoxContainer/HBoxContainer/SpritesheetOptions"]
+[node name="HorizontalFrames" type="SpinBox" parent="VBoxContainer/HBoxContainer/SpritesheetTabOptions"]
 margin_left = 122.0
 margin_right = 196.0
 margin_bottom = 24.0
@@ -105,18 +103,38 @@ mouse_default_cursor_shape = 2
 min_value = 1.0
 value = 1.0
 
-[node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer/SpritesheetOptions"]
+[node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer/SpritesheetTabOptions"]
 margin_left = 200.0
 margin_top = 5.0
 margin_right = 300.0
 margin_bottom = 19.0
 text = "Vertical frames:"
 
-[node name="VerticalFrames" type="SpinBox" parent="VBoxContainer/HBoxContainer/SpritesheetOptions"]
+[node name="VerticalFrames" type="SpinBox" parent="VBoxContainer/HBoxContainer/SpritesheetTabOptions"]
 margin_left = 304.0
 margin_right = 378.0
 margin_bottom = 24.0
 mouse_default_cursor_shape = 2
+min_value = 1.0
+value = 1.0
+
+[node name="SpritesheetLayerOptions" type="HBoxContainer" parent="VBoxContainer/HBoxContainer"]
+visible = false
+margin_left = 155.0
+margin_right = 692.0
+margin_bottom = 24.0
+
+[node name="Label3" type="Label" parent="VBoxContainer/HBoxContainer/SpritesheetLayerOptions"]
+margin_left = 382.0
+margin_top = 5.0
+margin_right = 459.0
+margin_bottom = 19.0
+text = "Start Frame:"
+
+[node name="AtFrameSpinbox" type="SpinBox" parent="VBoxContainer/HBoxContainer/SpritesheetLayerOptions"]
+margin_left = 463.0
+margin_right = 537.0
+margin_bottom = 24.0
 min_value = 1.0
 value = 1.0
 
@@ -138,6 +156,41 @@ margin_right = 131.0
 margin_bottom = 24.0
 mouse_default_cursor_shape = 2
 max_value = 0.0
+
+[node name="ReplaceFrameOptions" type="HBoxContainer" parent="VBoxContainer/HBoxContainer"]
+visible = false
+margin_left = 155.0
+margin_right = 433.0
+margin_bottom = 24.0
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/ReplaceFrameOptions"]
+margin_top = 5.0
+margin_right = 56.0
+margin_bottom = 19.0
+text = "At Layer:"
+
+[node name="AtLayerSpinbox" type="SpinBox" parent="VBoxContainer/HBoxContainer/ReplaceFrameOptions"]
+margin_left = 60.0
+margin_right = 134.0
+margin_bottom = 24.0
+mouse_default_cursor_shape = 2
+max_value = 0.0
+
+[node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer/ReplaceFrameOptions"]
+margin_left = 138.0
+margin_top = 5.0
+margin_right = 200.0
+margin_bottom = 19.0
+text = "At Frame:"
+
+[node name="AtFrameSpinbox" type="SpinBox" parent="VBoxContainer/HBoxContainer/ReplaceFrameOptions"]
+margin_left = 204.0
+margin_right = 278.0
+margin_bottom = 24.0
+mouse_default_cursor_shape = 2
+min_value = 1.0
+max_value = 0.0
+value = 1.0
 
 [node name="NewLayerOptions" type="HBoxContainer" parent="VBoxContainer/HBoxContainer"]
 visible = false
@@ -201,6 +254,6 @@ margin_bottom = 24.0
 [connection signal="confirmed" from="." to="." method="_on_PreviewDialog_confirmed"]
 [connection signal="popup_hide" from="." to="." method="_on_PreviewDialog_popup_hide"]
 [connection signal="item_selected" from="VBoxContainer/HBoxContainer/ImportOption" to="." method="_on_ImportOption_item_selected"]
-[connection signal="value_changed" from="VBoxContainer/HBoxContainer/SpritesheetOptions/HorizontalFrames" to="." method="_on_HorizontalFrames_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/HBoxContainer/SpritesheetOptions/VerticalFrames" to="." method="_on_VerticalFrames_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/HBoxContainer/SpritesheetTabOptions/HorizontalFrames" to="." method="_on_HorizontalFrames_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/HBoxContainer/SpritesheetTabOptions/VerticalFrames" to="." method="_on_VerticalFrames_value_changed"]
 [connection signal="item_selected" from="VBoxContainer/HBoxContainer/NewBrushOptions/BrushTypeOption" to="." method="_on_BrushTypeOption_item_selected"]


### PR DESCRIPTION
* fixed some more bugs

* Removed some more bugs

* Added "Replace Frame" option

It was originally made to use primarily in "Spritesheet (new layer)" but it thought it could also be useful to put it there as an import option

* Update PreviewDialog.tscn

* Update PreviewDialog.gd

* Update OpenSave.gd

* added import option for SpriteSheet and Frame

Now we can add SpriteSheets in current project and Replace frames in current project

* added functions for SpriteSheet and Frames

I added functions that would allow me to add SpriteSheet as new Layer. I also added an option for "Replace frame" (the function "open_image_at_frame()" is originally being used in "open_image_as_spritesheet_layer()" method but i decided to use it as an import option as well)

* Changed contribution name

* Changed contribution name

* Fixed some lines

* fixed sprite lines not updating